### PR TITLE
Talk about nogil-integration branch, reorganize pyenv instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ that project's issue tracker.
 Currently we suggest building CPython from source using the latest version of
 the CPython `main` branch. There is also a "bleeding-edge" branch integrating
 several work-in-progress pull requests. You may have a more stable experience
-using the `nogil-integration` branch on [Sam Gross` fork of
+using the [`nogil-integration`
+branch](https://github.com/python/cpython/issues/116749) on [Sam Gross` fork of
 CPython](https://github.com/colesbury/cpython/tree/nogil-integration). See [the
 build
 instructions](https://devguide.python.org/getting-started/setup-building/index.html)

--- a/README.md
+++ b/README.md
@@ -22,11 +22,14 @@ that project's issue tracker.
 
 ### Building Free-Threaded CPython
 
-Currently we suggest building CPython from source using the latest
-version of the CPython `main` branch. See [the build
+Currently we suggest building CPython from source using the latest version of
+the CPython `main` branch. There is also a "bleeding-edge" branch integrating
+several work-in-progress pull requests. You may have a more stable experience
+using the `nogil-integration` branch on [Sam Gross` fork of
+CPython](https://github.com/colesbury/cpython/tree/nogil-integration). See [the
+build
 instructions](https://devguide.python.org/getting-started/setup-building/index.html)
-in the CPython developer guide. You will need to install [needed
-third-party
+in the CPython developer guide. You will need to install [needed third-party
 dependencies](https://devguide.python.org/getting-started/setup-building/index.html#install-dependencies)
 before building. To build the free-threaded version of CPython, pass
 `--disable-gil` to the `configure` script:
@@ -36,26 +39,6 @@ before building. To build the free-threaded version of CPython, pass
 ```
 
 If you will be switching Python versions often, it may make sense to
-build CPython using [pyenv](https://github.com/pyenv/pyenv). We suggest
-installing the
-[pyenv-suffix](https://github.com/AdrianDAlessandro/pyenv-suffix) plugin
-to distinguish between free-threaded and "standard" builds of CPython
-3.13:
-
-```bash
-CONFIGURE_OPTS="--disable-gil --with-pydebug"
-PYENV_VERSION_SUFFIX='-nogil' pyenv install -v 3.13-dev
-```
-
-You can then "activate" the installed free-threaded Python in your
-global shell environment with
-
-```bash
-pyenv global 3.13-dev-nogil
-```
-
-Or locally in a single directory with a `.python-version` file or with
-
-```bash
-pyenv local 3.13-dev-nogil
-```
+build CPython using [pyenv](https://github.com/pyenv/pyenv). See
+[the `pyenv` folder](pyenv/README.md) in this repository for more details
+managing free-threaded and non-free-threaded python installs with pyenv.

--- a/pyenv/3.13-dev
+++ b/pyenv/3.13-dev
@@ -1,0 +1,7 @@
+prefer_openssl3
+export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
+export PYTHON_BUILD_TCLTK_USE_PKGCONFIG=1
+export PYTHON_BUILD_CONFIGURE_WITH_DSYMUTIL=1
+install_package "openssl-3.1.2" "https://www.openssl.org/source/openssl-3.1.2.tar.gz#a0ce69b8b97ea6a35b96875235aa453b966ba3cba8af2de23657d8b6767d6539" mac_openssl --if has_broken_mac_openssl
+install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
+install_git "Python-3.13-dev" "https://github.com/colesbury/cpython" nogil-integration standard verify_py313 copy_python_gdb ensurepip

--- a/pyenv/README.md
+++ b/pyenv/README.md
@@ -1,0 +1,29 @@
+We suggest installing the
+[pyenv-suffix](https://github.com/AdrianDAlessandro/pyenv-suffix) plugin to
+distinguish between free-threaded and "standard" builds of CPython 3.13:
+
+```bash
+CONFIGURE_OPTS="--disable-gil" PYENV_VERSION_SUFFIX='-nogil' \
+pyenv install -v --debug 3.13-dev
+```
+
+You can then "activate" the installed free-threaded python in your
+global shell environment with
+
+```bash
+pyenv global 3.13-dev-nogil-debug
+```
+
+Or locally in a single directory with a `.python-version` file or with
+
+```bash
+pyenv local 3.13-dev-nogil-debug
+```
+
+To install the `nogil-integration` branch, clone this repository and
+install using the provided definition file in this folder:
+
+```bash
+CONFIGURE_OPTS="--disable-gil" PYENV_VERSION_SUFFIX='-nogil-integration' \
+pyenv install -v --debug /path/to/free-threaded-compatibility/pyenv/3.13-dev
+```


### PR DESCRIPTION
Reorganizes pyenv instructions into a sub-readme and adds a mention of the [`nogil-integration` branch](https://github.com/python/cpython/issues/116749). I added  a [custom definition file](https://github.com/pyenv/pyenv/tree/master/plugins/python-build#custom-definitions) for building that branch and mentioned it in the pyenv instructions.