### PR TITLE
Remove instructions for installing nogil-integration

### DIFF
--- a/pyenv/3.13-dev
+++ b/pyenv/3.13-dev
@@ -1,7 +1,0 @@
-prefer_openssl3
-export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
-export PYTHON_BUILD_TCLTK_USE_PKGCONFIG=1
-export PYTHON_BUILD_CONFIGURE_WITH_DSYMUTIL=1
-install_package "openssl-3.1.2" "https://www.openssl.org/source/openssl-3.1.2.tar.gz#a0ce69b8b97ea6a35b96875235aa453b966ba3cba8af2de23657d8b6767d6539" mac_openssl --if has_broken_mac_openssl
-install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_git "Python-3.13-dev" "https://github.com/colesbury/cpython" nogil-integration standard verify_py313 copy_python_gdb ensurepip

--- a/pyenv/README.md
+++ b/pyenv/README.md
@@ -20,10 +20,19 @@ Or locally in a single directory with a `.python-version` file or with
 pyenv local 3.13-dev-nogil-debug
 ```
 
-To install the `nogil-integration` branch, clone this repository and
-install using the provided definition file in this folder:
+Note that debug builds of python are substantially slower. You can drop
+`--debug` from the `pyenv install` invocation if you would like an optimized 
+build. The resulting pyenv environments will not have a `-debug` suffix in 
+their names.
+
+You can simultaneously install the build of python with the GIL enabled with
 
 ```bash
-CONFIGURE_OPTS="--disable-gil" PYENV_VERSION_SUFFIX='-nogil-integration' \
-pyenv install -v --debug /path/to/free-threaded-compatibility/pyenv/3.13-dev
+pyenv install -v --debug 3.13-dev
+```
+
+The resulting environment can be activated with
+
+```bash
+pyenv global 3.13-dev
 ```


### PR DESCRIPTION
Also added a little bit more explanatory text.

If we ever need the environment again we can always bring the pyenv environment definition back.

Fixes #8