### PR TITLE
Add instructions for installing custom CPython builds

### DIFF
--- a/pyenv/README.md
+++ b/pyenv/README.md
@@ -36,3 +36,21 @@ The resulting environment can be activated with
 ```bash
 pyenv global 3.13-dev
 ```
+
+If you need to install a CPython development tree, either locally or on GitHub,
+you can do so using a [custom
+definition](https://github.com/pyenv/pyenv/blob/master/plugins/python-build/README.md#custom-definitions),
+e.g. based on the definition for
+[3.13-dev](https://github.com/pyenv/pyenv/blob/master/plugins/python-build/share/python-build/3.13-dev). Replace
+the repository used in that definition with a CPython fork or local clone and
+replace `3.13` with the branch you would like to build. The commit you would
+like to build must have a branch pointing to it. If your custom definition
+should have the same name as the original definition, but with edited paths and
+branch names. Install it with e.g. this command:
+
+```bash
+CONFIGURE_OPTS=--disable-gil PYENV_VERSION_SUFFIX='-nogil-branch' pyenv install -v ./3.13-dev
+```
+
+And it will be available to activate via the `pyenv` CLI with the name
+`3.13-dev-nogil-branch`.


### PR DESCRIPTION
We had something like this in here to install the `nogil-integration` branch. I found it useful to do this when I had to bisect CPython to understand a test failure introduced right before the beta was released, so I figure it's worth preserving the instructions. Let's add the docs back for how to do this for an arbitrary git branch and repo.