### PR TITLE
Fix CPython version typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ You can verify your build has the GIL disabled with the following incantation:
 python -VV
 ```
 
-If you are using Python 3.13b2 or newer, you should see a message like:
+If you are using Python 3.13b1 or newer, you should see a message like:
 
 ```bash
 Python 3.13.0b1+ experimental free-threading build (heads/3.13:d93c4f9, May 21 2024, 10:54:14) [Clang 15.0.0 (clang-1500.1.0.2.5)]


### PR DESCRIPTION
3.13b2 has not been released yet, it is planned on June 4th according to https://peps.python.org/pep-0719/#schedule