### PR TITLE
Add `pip install -i` example in tracking page

### DIFF
--- a/docs/tracking.md
+++ b/docs/tracking.md
@@ -12,7 +12,7 @@ hence this page does not aim to track pure Python packages.
     widely used libraries with extension modules are being fixed every week.
     It may be useful to use nightly wheels (when available) of packages
     like `cython` or `numpy`, even if a first release is available on PyPI.
-    You can do so by running:
+    For example, you can install a NumPy nightly wheel by running:
 
     ```
     pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy

--- a/docs/tracking.md
+++ b/docs/tracking.md
@@ -12,6 +12,11 @@ hence this page does not aim to track pure Python packages.
     widely used libraries with extension modules are being fixed every week.
     It may be useful to use nightly wheels (when available) of packages
     like `cython` or `numpy`, even if a first release is available on PyPI.
+    You can do so by running:
+
+    ```
+    pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
+    ```
 
 
 <!-- keep alphabetically ordered -->


### PR DESCRIPTION
A lot of people will be visiting the website just to view this list. Provide an example of how to install nightlies so that they don't have to search around.