### PR TITLE
Fix example version in GitHub actions

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@...
     - uses: deadsnakes/action@...
       with:
-          python-version: '3.13.0b2'
+          python-version: '3.13-dev'
           nogil: true
 ```
 


### PR DESCRIPTION
The example for the docs gives me the following error:

```
Run deadsnakes/action@v3.1.0
  with:
    python-version: 3.13.0b3
    nogil: true
    debug: false
Run /home/runner/work/_actions/deadsnakes/action/v3.1.0/bin/install-python 3.13.0b3  --nogil
Traceback (most recent call last):
  File "/home/runner/work/_actions/deadsnakes/action/v3.1.0/bin/install-python", line 113, in <module>
    raise SystemExit(main())
  File "/home/runner/work/_actions/deadsnakes/action/v3.1.0/bin/install-python", line 51, in main
    major_s, minor_s = version.split('.')
ValueError: too many values to unpack (expected 2)
```

Looks like the action expects 2 digits