### PR TITLE
docs: combine Cython, C, and pybind11 parts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Build site
-        run: mkdocs build
+        run: mkdocs build --strict
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0


### PR DESCRIPTION
I noticed this now has some duplicated information, and someone looking for pybind11 or C API information shouldn't have to read paragraphs about Cython directives. I've build this locally to make sure the nested tabs work.
