### PR TITLE
change to conda-forge cpython instructions

### DIFF
--- a/docs/installing_cpython.md
+++ b/docs/installing_cpython.md
@@ -122,13 +122,10 @@ and installing the free-threaded binaries is also possible:
     sudo apt-get install python3.13-nogil
     ```
 
-### Conda
-
-Conda packages are currently available for macOS arm64 and Linux x86-64 under a
-label in the `ad-testing` (`ad` means "anaconda distribution") channel:
+### Conda-forge
 
 ```bash
-conda create -n nogil -c defaults -c ad-testing/label/py313_nogil python=3.13
+mamba create -n nogil -c conda-forge/label/python_rc python-freethreading
 ```
 
 ## Containers


### PR DESCRIPTION
ref https://github.com/scipy/scipy/issues/21479#issuecomment-2334947851

Based on the guidance at https://anaconda.org/conda-forge/python-freethreading.

I can't actually get this to work locally: `_python_rc does not exist (perhaps a typo or a missing channel).`