### PR TITLE
Add return to example in porting.md

### DIFF
--- a/docs/porting.md
+++ b/docs/porting.md
@@ -55,6 +55,8 @@ after importing a module that does not support the GIL.
     #ifdef Py_GIL_DISABLED
         PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED);
     #endif
+
+        return mod;
     }
     ```
 


### PR DESCRIPTION
Since we have the closing bracket there, adding the return statement that should be before this bracket.
I can also remove the closing bracket if you prefer.