### PR TITLE
Update TOC on index page, make headers uniform

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,4 +1,4 @@
-# Uncovering concurrency issues, testing and debugging
+# Uncovering Concurrency Issues, Testing and Debugging
 
 Until now, the GIL has allowed developers to ignore C
 safety issues when writing parallel programs, since the GIL ensured that

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,17 +16,18 @@ maintainers and end users interested in supporting or experimenting with
 free-threaded Python. An overview of the compatibility status of various Python
 libraries is maintained in:
 
-- [Compatibility status tracking](tracking.md)
+- [Compatibility Status Tracking](tracking.md)
 
 This website also provide documentation and porting guidance - with a focus on
 extension modules using the Python C API, because that's where most of the work
 will be. The following resources should get you started:
 
-- [Installing free-threaded CPython](installing_cpython.md)
-- [Running Python with the GIL disabled](running-gil-disabled.md)
-- [Porting extension modules to support free-threading](porting.md)
+- [Installing Free-Threaded Python](installing_cpython.md)
+- [Running Python with the GIL Disabled](running-gil-disabled.md)
+- [Porting Python Packages to Support Free-Threading](porting.md)
 - [Setting up CI](ci.md)
-- [Finding, testing and debugging concurrency issues](debugging.md)
+- [Uncovering Concurrency Issues, Testing and Debugging](debugging.md)
+- [More Resources](resources.md)
 
 ## About this site
 

--- a/docs/installing_cpython.md
+++ b/docs/installing_cpython.md
@@ -1,4 +1,4 @@
-# Installing a free-threaded Python
+# Installing Free-Threaded Python
 
 To install a free-threaded CPython interpreter, you can either use a pre-built
 binary or build CPython from source. The former is quickest to get started

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -1,4 +1,4 @@
-# More resources
+# More Resources
 
 Apart from this website, there's a wide list of resources on the
 free-threaded build and free-threading topics in general, including

--- a/docs/running-gil-disabled.md
+++ b/docs/running-gil-disabled.md
@@ -1,4 +1,4 @@
-# Running with the GIL disabled
+# Running Python with the GIL Disabled
 
 !!! info
     Most of the content on this page is also covered in the Python 3.13

--- a/docs/tracking.md
+++ b/docs/tracking.md
@@ -1,4 +1,4 @@
-# Compatibility status tracking
+# Compatibility Status Tracking
 
 This page tracks the status of packages for which we're aware of active work on
 free-threaded support. It contains packages with extension modules, as well


### PR DESCRIPTION
I noticed today that the TOC on the main index has gone out sync with the generated index sidebar.

I don't see a way in mkdocs to generate the link text automatically, so I just manually updated them all. I also took the opportunity to uniformly put everything in title case.