### PR TITLE
add note about MacOS malloc warnings for tsan build

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -300,7 +300,6 @@ make install
 ```
 
 !!! note
-
     On MacOS, you may see messages like this when you start Python:
 
     ```
@@ -312,7 +311,7 @@ make install
     here](https://stackoverflow.com/questions/64126942/malloc-nano-zone-abandoned-due-to-inability-to-preallocate-reserved-vm-space),
     this happens for any program compiled with thread sanitizer on MacOS and can
     be safely ignored by setting the `MallocNanoZone` environment variable to
-    0. You should only set this in session you are running thread sanitizer
+    0\. You should only set this in session you are running thread sanitizer
     under, as this setting will slow down other programs that allocate memory.
 
 - To use the built Python interpreter:

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -299,6 +299,22 @@ make -j 8
 make install
 ```
 
+!!! note
+
+    On MacOS, you may see messages like this when you start Python:
+
+    ```
+    python(7027,0x1f6dfc240) malloc: nano zone abandoned due to inability to reserve vm space.
+    ```
+
+    This message is being emmitted by the MacOS malloc implementation. As
+    [explained
+    here](https://stackoverflow.com/questions/64126942/malloc-nano-zone-abandoned-due-to-inability-to-preallocate-reserved-vm-space),
+    this happens for any program compiled with thread sanitizer on MacOS and can
+    be safely ignored by setting the `MallocNanoZone` environment variable to
+    0. You should only set this in session you are running thread sanitizer
+    under, as this setting will slow down other programs that allocate memory.
+
 - To use the built Python interpreter:
 
 ```bash

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -299,21 +299,6 @@ make -j 8
 make install
 ```
 
-!!! note
-    On MacOS, you may see messages like this when you start Python:
-
-    ```
-    python(7027,0x1f6dfc240) malloc: nano zone abandoned due to inability to reserve vm space.
-    ```
-
-    This message is being emmitted by the MacOS malloc implementation. As
-    [explained
-    here](https://stackoverflow.com/questions/64126942/malloc-nano-zone-abandoned-due-to-inability-to-preallocate-reserved-vm-space),
-    this happens for any program compiled with thread sanitizer on MacOS and can
-    be safely ignored by setting the `MallocNanoZone` environment variable to
-    0\. You should only set this in session you are running thread sanitizer
-    under, as this setting will slow down other programs that allocate memory.
-
 - To use the built Python interpreter:
 
 ```bash
@@ -330,6 +315,21 @@ PYTHON_GIL=0 python -c "import sys; print(sys._is_gil_enabled())"
 # Exit the `cpython` folder (preparation for the next step below)
 cd ..
 ```
+
+!!! note
+    On MacOS, you may see messages like this when you start Python:
+
+    ```
+    python(7027,0x1f6dfc240) malloc: nano zone abandoned due to inability to reserve vm space.
+    ```
+
+    This message is being emmitted by the MacOS malloc implementation. As
+    [explained
+    here](https://stackoverflow.com/questions/64126942/malloc-nano-zone-abandoned-due-to-inability-to-preallocate-reserved-vm-space),
+    this happens for any program compiled with thread sanitizer on MacOS and can
+    be safely ignored by setting the `MallocNanoZone` environment variable to
+    0\. You should only set this in session you are running thread sanitizer
+    under, as this setting will slow down other programs that allocate memory.
 
 ### Compile NumPy with TSAN
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -328,7 +328,7 @@ cd ..
     here](https://stackoverflow.com/questions/64126942/malloc-nano-zone-abandoned-due-to-inability-to-preallocate-reserved-vm-space),
     this happens for any program compiled with thread sanitizer on MacOS and can
     be safely ignored by setting the `MallocNanoZone` environment variable to
-    0. You should only set this in session you are running thread sanitizer
+    0\. You should only set this in session you are running thread sanitizer
     under, as this setting will slow down other programs that allocate memory.
 
 ### Compile NumPy with TSAN

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -351,13 +351,7 @@ python -m pip install -U git+https://github.com/cython/cython
 - Build the package
 
 ```bash
-export CC=clang-18
-export CXX=clang++-18
-export CFLAGS=-fsanitize=thread
-export CXXFLAGS=-fsanitize=thread
-export LDFLAGS=-fsanitize=thread
-
-python -m pip install -v . --no-build-isolation
+CC=clang-18 CXX=clang++-18 python -m pip install -v . --no-build-isolation -C'setup-args=-Db_sanitize=thread
 ```
 
 ### Useful TSAN options

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -328,7 +328,7 @@ cd ..
     here](https://stackoverflow.com/questions/64126942/malloc-nano-zone-abandoned-due-to-inability-to-preallocate-reserved-vm-space),
     this happens for any program compiled with thread sanitizer on MacOS and can
     be safely ignored by setting the `MallocNanoZone` environment variable to
-    0\. You should only set this in session you are running thread sanitizer
+    0. You should only set this in session you are running thread sanitizer
     under, as this setting will slow down other programs that allocate memory.
 
 ### Compile NumPy with TSAN
@@ -351,7 +351,7 @@ python -m pip install -U git+https://github.com/cython/cython
 - Build the package
 
 ```bash
-CC=clang-18 CXX=clang++-18 python -m pip install -v . --no-build-isolation -C'setup-args=-Db_sanitize=thread
+CC=clang-18 CXX=clang++-18 python -m pip install -v . --no-build-isolation -Csetup-args=-Db_sanitize=thread
 ```
 
 ### Useful TSAN options


### PR DESCRIPTION
I wasted 15 minutes or so trying to understand this warning, so I think it's fair to link to an explanation.