### PR TITLE
Upgrade CI jobs and pre-commit hooks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,11 +27,11 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
 
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: 3.12
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,15 +10,15 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: 3.11  # Cause beautysh (used in a pre-commit hook) does not support 3.12
 
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
 
-      - uses: pre-commit-ci/lite-action@9d882e7a565f7008d4faf128f27d1cb6503d4ebf # v1.0.2
+      - uses: pre-commit-ci/lite-action@5d6cc0eb514c891a40562a58a8e71576c5c7fb43 # v1.1.0
         if: always()

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: requirements-txt-fixer
 
   - repo: https://github.com/executablebooks/mdformat
-    rev: 42b9462bb3d6f151faff3cd5c6426d6531474f50 # 0.7.18
+    rev: 83dc2ce5ca115d3390b9b5561d2898366faf0742 # 0.7.22
     hooks:
       - id: mdformat
         additional_dependencies:

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -114,6 +114,7 @@ dependencies do the same. See [the porting guide](porting.md) for more
 information about declaring support for free-threaded python in your extension.
 
 !!! info
+
     If a dependency of your package does not support free-threading or has not
     yet done a release which includes `cp313t` wheels, this can be tricky to
     work around because an environment marker for free-threading does not exist

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -317,6 +317,7 @@ cd ..
 ```
 
 !!! note
+
     On MacOS, you may see messages like this when you start Python:
 
     ```
@@ -337,7 +338,7 @@ cd ..
 
 ```bash
 git clone --recursive \
-https://github.com/numpy/numpy.git
+    https://github.com/numpy/numpy.git
 ```
 
 - Install the build requirements:

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -336,7 +336,8 @@ cd ..
 - Get the source code (for example, the `main` branch)
 
 ```bash
-git clone --recursive https://github.com/numpy/numpy.git
+git clone --recursive \
+https://github.com/numpy/numpy.git
 ```
 
 - Install the build requirements:

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -337,8 +337,7 @@ cd ..
 - Get the source code (for example, the `main` branch)
 
 ```bash
-git clone --recursive \
-    https://github.com/numpy/numpy.git
+git clone --recursive https://github.com/numpy/numpy.git
 ```
 
 - Install the build requirements:

--- a/docs/installing_cpython.md
+++ b/docs/installing_cpython.md
@@ -12,12 +12,14 @@ There are a growing number of options to install a free-threaded interpreter,
 from the python.org installers to Linux distro and Conda package managers.
 
 !!! note
+
     For any of these options, please check after the install succeeds that you
     have a `pip` version that is recent enough (`>=24.1`), and upgrade it if
     that isn't the case. Older `pip` versions will select wheels with the
     `cp313` tag (binary-incompatible) rather than the `cp313t` tag.
 
 ??? question "As a packager, what should I name the package and interpreter?"
+
     Please see [this guidance from the Python Steering Council](https://github.com/python/steering-council/issues/221#issuecomment-1841593283)
 
 ### python.org and nuget installers
@@ -26,7 +28,7 @@ The [python.org downloads page](https://www.python.org/download/pre-releases/)
 provides macOS and Windows installers that have experimental support.
 
 Note that you have to customize the install - e.g., for Windows there is a
-_Download free-threaded binaries_ checkbox under "Advanced Options".  See also
+_Download free-threaded binaries_ checkbox under "Advanced Options". See also
 the [Using Python on
 Windows](https://docs.python.org/3.13/using/windows.html#installing-free-threaded-binaries)
 section of the Python 3.13 docs.
@@ -35,6 +37,7 @@ Automating the process of downloading the official installers
 and installing the free-threaded binaries is also possible:
 
 === "Windows"
+
     Due to limitations of the Windows Python.org installer, using free-threaded Python
     installed from the Python.org installer may lead to trouble. In particular, if you
     install both a free-threaded and gil-enabled build of Python 3.13 using the Python.org
@@ -74,6 +77,7 @@ and installing the free-threaded binaries is also possible:
     for more information.
 
 === "macOS"
+
     On macOS, you can use `installer` to install a macOS package you've
     downloaded:
 
@@ -112,6 +116,7 @@ and installing the free-threaded binaries is also possible:
 ### Linux distros
 
 === "Fedora"
+
     Fedora ships a packaged version, which you can install with:
 
     ```bash
@@ -121,6 +126,7 @@ and installing the free-threaded binaries is also possible:
     This will install the interpreter at `/usr/bin/python3.13t`.
 
 === "Nixpkgs"
+
     Nixpkgs provides cached builds under the [`python313FreeThreading`](https://search.nixos.org/packages?channel=unstable&show=python313FreeThreading&type=packages)
     attribute from NixOS 24.05 and newer.
 
@@ -138,6 +144,7 @@ and installing the free-threaded binaries is also possible:
     ```
 
 === "Ubuntu"
+
     For Ubuntu you can use the [deadsnakes PPA](https://launchpad.net/%7Edeadsnakes/+archive/ubuntu/ppa/+packages)
     by adding it to your repositories and then installing `python3.13-nogil`:
 
@@ -150,6 +157,7 @@ and installing the free-threaded binaries is also possible:
 ### Multi-platform Package Managers
 
 === "Conda-forge"
+
     ```bash
     mamba create -n nogil -c conda-forge python-freethreading
     ```
@@ -161,8 +169,9 @@ and installing the free-threaded binaries is also possible:
     ```
 
 === "Anaconda Testing"
+
     Anaconda's test channel includes the Python interpreter and ABI-compatible
-    builds of many common packages, like NumPy, Cython, Pandas, etc.  These
+    builds of many common packages, like NumPy, Cython, Pandas, etc. These
     packages use the `python_abi` metapackage and should be compatible with
     conda-forge:
 
@@ -173,6 +182,7 @@ and installing the free-threaded binaries is also possible:
     [Full list of Anaconda test packages built with free-threading ABI.](https://anaconda.org/ad-testing/repo?label=py313_nogil&type=any)
 
 === "Homebrew"
+
     On macOS and Linux, you can use Homebrew:
 
     ```bash

--- a/docs/porting.md
+++ b/docs/porting.md
@@ -26,6 +26,7 @@ disabled, otherwise a warning is printed and the GIL is re-enabled at runtime
 after importing a module that does not support the GIL.
 
 === "C API"
+
     C or C++ extension modules using multi-phase initialization can specify the
     [`Py_mod_gil`](https://docs.python.org/3.13/c-api/module.html#c.Py_mod_gil)
     module slot like this:
@@ -64,6 +65,7 @@ after importing a module that does not support the GIL.
     ```
 
 === "Pybind11"
+
     C++ extension modules making use of `pybind11` can easily declare support for
     running with the GIL disabled via the
     [`gil_not_used`](https://pybind11.readthedocs.io/en/stable/reference.html#_CPPv4N7module_23create_extension_moduleEPKcPKcP10module_def16mod_gil_not_used)
@@ -79,6 +81,7 @@ after importing a module that does not support the GIL.
     ```
 
 === "Cython"
+
     Cython code can be thread-unsafe and just like C and C++ code can exhibit
     undefined behavior due to data races.
 
@@ -118,10 +121,12 @@ after importing a module that does not support the GIL.
     Or via a build system specific way of passing directives to Cython.
 
     !!! tip
+
         Here are a few examples of how to globally enable the directive in a few popular
         build systems:
 
         === "setuptools"
+
             When using setuptools, you can pass the `compiler_directives` keyword argument
             to `cythonize`:
 
@@ -142,6 +147,7 @@ after importing a module that does not support the GIL.
             ```
 
         === "Meson"
+
             When using Meson, you can add the directive to the `cython_args` you're
             passing to `py.extension_module`:
 
@@ -174,6 +180,7 @@ after importing a module that does not support the GIL.
     how to build projects that depend on Cython.
 
 === "Rust"
+
     If you use the CPython C API via [PyO3](https://pyo3.rs), then you
     can follow the [PyO3 Guide
     section](https://pyo3.rs/latest/free-threading.html) on supporting
@@ -215,6 +222,7 @@ after importing a module that does not support the GIL.
     the PyO3 source code.
 
 === "f2py"
+
     Starting with NumPy 2.1.0, extension modules containing f2py-wrapped
     Fortran code can declare they are thread-safe and support free-threading
     using the
@@ -537,6 +545,7 @@ int function_accessing_the_cache(void) {
 ```
 
 !!! note
+
     Note that, while the NumPy PR linked above uses `PyThread_type_lock`, that is
     only because `PyMutex` was not part of the public Python C API at the time. We
     recommend always using `PyMutex`. For pointers on how to do that, check

--- a/docs/running-gil-disabled.md
+++ b/docs/running-gil-disabled.md
@@ -1,10 +1,12 @@
 # Running Python with the GIL Disabled
 
 !!! info
+
     Most of the content on this page is also covered in the Python 3.13
     [release notes](https://docs.python.org/3.13/whatsnew/3.13.html#free-threaded-cpython).
 
 !!! note
+
     The free-threaded Python executable will always have a `python3.13t` alias
     (for Python 3.13); whether `python`, `python3` and/or `python3.13` point at
     the free-threaded executable or not will depend on the installation method

--- a/docs/tracking.md
+++ b/docs/tracking.md
@@ -19,6 +19,7 @@ an issue spans multiple projects or there's an ecosystem-wide point to discuss,
 please open an issue on [this issue tracker](https://github.com/Quansight-Labs/free-threaded-compatibility/issues).
 
 !!! tip
+
     It's early days for free-threaded support - bugs in CPython itself and in
     widely used libraries with extension modules are being fixed every week.
     It may be useful to use nightly wheels (when available) of packages


### PR DESCRIPTION
- Upgrade version of the pre-commit lite action to fix the issues the autofix has been having
- Took the opportunity to also upgrade all others to the latest versions.

Closes #136.