### PR TITLE
Update section about setup-python

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,8 +1,17 @@
 # Setting up CI
 
-Currently the `setup-python` GitHub Action [does not
-support](https://github.com/actions/setup-python/issues/771) installing a
-free-threaded build. For now, here are some relatively easy ways:
+## CI setup via `setup-python`
+
+```yaml
+jobs:
+  free-threaded:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@...
+      - uses: actions/setup-python@...
+        with:
+          python-version: 3.13t
+```
 
 ## CI setup via `setup-uv`
 


### PR DESCRIPTION
setup-python now supports free-threaded, see [blog post](https://hugovk.dev/blog/2025/free-threaded-python-on-github-actions/) for example.

I wrote this following the blog post but it's not tested, please double-check :wink:.

It may be worth mentioning that free-threaded support happened in [setup-python v5.5](https://github.com/actions/setup-python/releases/tag/v5.5.0), otherwise I guess if the setup-python is too old there will be an error.