### PR TITLE
Add support for mkdocs material code copy button

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ copyright: Copyright &copy; 2024- Quansight Labs & open source contributors
 theme:
   name: material
   features:
+    - content.code.copy
     - header.autohide
   palette:
     # Palette toggle for dark mode


### PR DESCRIPTION
This PR adds a copy button to code blocks. See https://squidfunk.github.io/mkdocs-material/reference/code-blocks/?h=code+copy#code-copy-button 