### PR TITLE
DOC: release lock on exception

### DIFF
--- a/docs/porting.md
+++ b/docs/porting.md
@@ -271,7 +271,7 @@ lock.
 
 Finally, note how the above code will ensure that only a single call to
 `_do_expensive_calculation` will run at any given time, regardless of `arg`.
-This may not be desirable; one would want to allow calling the function in
+This may not be desirable; one could want to allow calling the function in
 parallel for different arguments. In that case, you need a separate lock for each
 `arg` - but you also need a global lock to manage your collection of locks!
 

--- a/docs/porting.md
+++ b/docs/porting.md
@@ -253,7 +253,7 @@ avoid using
 [`Lock.acquire`](https://docs.python.org/3/library/threading.html#threading.Lock.acquire)
 and [`Lock.release`](https://docs.python.org/3/library/threading.html#threading.Lock.release)
 and instead we use the lock as a context manager. The difference is subtle: the context
-manager calls `Lock.release` in a `try...finally` clause, so if
+manager calls `Lock.release` in a `try` ... `finally` clause, so if
 `_do_expensive_calculation` were to raise an exception, this ensures that the lock won't
 stay locked forever.
 

--- a/docs/porting.md
+++ b/docs/porting.md
@@ -412,11 +412,10 @@ class SafeCounter:
         self.lock = threading.Lock()
 
     def increment(self):
-        self.lock.acquire()
-        current_value = self.value
-        time.sleep(random.randint(0, 10) * 0.0001)
-        self.value = current_value + 1
-        self.lock.release()
+        with self.lock:
+            current_value = self.value
+            time.sleep(random.randint(0, 10) * 0.0001)
+            self.value = current_value + 1
 ```
 
 If you replace `RaceyCounter` with `SafeCounter` in the script above, it will

--- a/docs/porting.md
+++ b/docs/porting.md
@@ -300,6 +300,7 @@ def do_calculation(arg):
     finally:
         lock.release()
         # Ignore a potential double deletion.
+        # Don't assume `cache_locks.pop(arg)` to be thread-safe.
         try:
             del cache_locks[arg]
         except KeyError:

--- a/docs/porting.md
+++ b/docs/porting.md
@@ -292,8 +292,8 @@ def do_calculation(arg):
     with cache_locks_lock:
         # Note: setdefault() is not atomic!
         lock = cache_locks.setdefault(threading.Lock())
-        lock.acquire()
 
+    lock.acquire()
     try:
         if arg not in global_cache:
             global_cache[arg] = _do_expensive_calculation(arg)


### PR DESCRIPTION
The tutorial on how to handle a global cache was causing the cache lock to be locked forever if the wrapped function raises.

I think it is also worth pointing out how you may not want to block for different values of the function argument / cache key.