### PR TITLE
DOC: Bad example of expensive add

### DIFF
--- a/docs/porting.md
+++ b/docs/porting.md
@@ -330,7 +330,7 @@ real example might have a method that looks something like this:
 
 ```python
 def increment(self):
-    self.value += do_some_expensive_calulation()
+    self.value = do_some_expensive_calulation(self.value)
 ```
 
 If we run this example in a thread pool, you'll see that the answer you get will


### PR DESCRIPTION
The documentation shows a "real" example of an expensive `increment` method.
The example however is not right - unless the output of `do_some_expensive_calulation` is an object that defines a complex `__radd__` method (say, a numpy array), the integer increment is executed by a single bytecode. In fact, it is atomic when the GIL enabled.