### PR TITLE
update Quansight-Labs/cffi to Quansight-Labs/cffi-ft

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -11,13 +11,13 @@ fork themselves](https://github.com/python-cffi/cffi/pull/143#issuecomment-25807
 so that free-threading support can be implemented and tested independently
 from the upstream package.
 
-There's [a fork under the Quansight-Labs org](https://github.com/Quansight-Labs/cffi)
+There's [a fork under the Quansight-Labs org](https://github.com/Quansight-Labs/cffi-ft)
 available, where free-threading support is currently being worked on. If you want to
 use this version of CFFI within your own library, you can install it in the
 following manner:
 
 ```bash
-python -m pip install git+https://github.com/Quansight-Labs/cffi.git
+python -m pip install git+https://github.com/Quansight-Labs/cffi-ft.git
 ```
 
 Keep in mind that support for free-threading in this fork of CFFI is still very

--- a/docs/tracking.md
+++ b/docs/tracking.md
@@ -113,7 +113,7 @@ please open an issue on [this issue tracker](https://github.com/Quansight-Labs/f
 
 [^1]: Release available in the [Bazel Central Registry](https://registry.bazel.build)
 
-[^2]: There's [a fork of cffi](https://github.com/Quansight-Labs/cffi) available
+[^2]: There's [a fork of cffi](https://github.com/Quansight-Labs/cffi-ft) available
     with support for free-threading. More details on our [CFFI section on
     dependencies that does not current support
     free-threading](dependencies.md#cffi-fork-with-support-for-free-threading).


### PR DESCRIPTION
I renamed the repo: https://github.com/Quansight-Labs/cffi-ft