### PR TITLE
Fix typo in discussion of backports.zstd

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -69,5 +69,5 @@ It is unnecessary to use PyYAML-ft unless you **must** support Python 3.13t.
 
 Python 3.14 includes the new [`compression.zstd`
 module](https://docs.python.org/3.14/library/compression.zstd.html#module-compression.zstd), backports are available
-under [backport.zstd](https://pypi.org/project/backports.zstd/) for Python 3.9-3.13 and can replace the
+under [backports.zstd](https://pypi.org/project/backports.zstd/) for Python 3.9-3.13 and can replace the
 [zstandard](https://pypi.org/project/zstandard/) package.


### PR DESCRIPTION
As pointed out here: https://github.com/Quansight-Labs/free-threaded-compatibility/pull/269#discussion_r2415037790