### PR TITLE
Use calendar link instead of event link for docs meeting

### DIFF
--- a/docs/docs-meeting.md
+++ b/docs/docs-meeting.md
@@ -6,7 +6,7 @@ efforts.
 
 ## Meeting Details
 
-**When**: Second Monday of every month at 4:00 PM UTC (1 hour)
+**When**: [Second Monday of every month at 4:00 PM UTC (1 hour)](https://calendar.google.com/calendar/u/0?cid=Y19hZTdhMzJiYzQ3OWFiY2JiY2JjNGU5MmI0ZWZhNWQ4MGZjMGVkNTY2N2Y4NjY5YzJkODQ1N2ViMmI4M2ExNGY1QGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20)
 
 **Where**: [Google Meet](https://meet.google.com/dqw-qkeg-jnh)
 
@@ -16,12 +16,6 @@ Everyone is welcome to join! The meeting provides an opportunity to:
 - Share experiences with free-threading adoption
 - Coordinate community efforts
 - Ask questions and get help
-
-## Add to Your Calendar
-
-Click the button below to add the monthly meeting to your Google Calendar:
-
-<a target="_blank" href="https://calendar.google.com/calendar/event?action=TEMPLATE&amp;tmeid=NzZhcmY5cXF0YnBzcnBjaTFuajg2aGN1c2ZfMjAyNTEyMDhUMTYwMDAwWiBjX2FlN2EzMmJjNDc5YWJjYmJjYmM0ZTkyYjRlZmE1ZDgwZmMwZWQ1NjY3Zjg2NjljMmQ4NDU3ZWIyYjgzYTE0ZjVAZw&amp;tmsrc=c_ae7a32bc479abcbbcbc4e92b4efa5d80fc0ed5667f8669c2d8457eb2b83a14f5%40group.calendar.google.com&amp;scp=ALL"><img border="0" src="https://calendar.google.com/calendar/images/ext/gc_button1_en.gif" alt="Google Calendar"></a>
 
 ## Questions?
 


### PR DESCRIPTION
Use calendar link for the free-threading docs meeting, since the event link seems to be changing every time event details are changing.