### PR TITLE
[FIX] fix typo in admonition

### DIFF
--- a/docs/installing-cpython.md
+++ b/docs/installing-cpython.md
@@ -48,7 +48,7 @@ and installing the free-threaded binaries is also possible:
     separate `python-freethreaded` package that does not share an installation
     with the `python` package.
 
-    !!! note:
+    !!! note
 
         Update the various places in below script to reflect your desired
         python version.


### PR DESCRIPTION
Should fix a failed admonition on this page:

https://py-free-threading.github.io/installing-cpython/#install-binaries-directly

<img width="1084" height="430" alt="image" src="https://github.com/user-attachments/assets/a36887d1-e777-4974-86c9-fa400a3a1e7c" />
