### PR TITLE
docs: project examples (Bengal)

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -13,12 +13,13 @@ External examples:
 - [Benchmarking a web service on the free-threaded build](https://blog.baro.dev/p/the-future-of-python-web-services-looks-gil-free)
 - [Improved Data Loading on GPUs with Threads](https://developer.nvidia.com/blog/improved-data-loading-with-threads/)
 - [Using `AtomicDict.reduce()` for Multithreaded Aggregation](https://dpdani.github.io/cereggii/examples/AtomicDict/reduce/)
-- [Thread-based ASGI workers with shared immutable config](https://github.com/lbliii/pounce) ([docs](https://lbliii.github.io/pounce/))
-- [`ContextVar` isolation for per-request state in a web framework](https://github.com/lbliii/chirp) ([docs](https://lbliii.github.io/chirp/))
-- [AST compilation with copy-on-write filter chains (PEP 703)](https://github.com/lbliii/kida) ([docs](https://lbliii.github.io/kida/))
-- [Parallel document parsing with an immutable AST](https://github.com/lbliii/patitas) ([docs](https://lbliii.github.io/patitas/))
-- [Immutable state machines for thread-safe syntax highlighting](https://github.com/lbliii/rosettes) ([docs](https://lbliii.github.io/rosettes/))
-- [Parallel page rendering with thread-safe dependency tracking](https://github.com/lbliii/bengal) ([docs](https://lbliii.github.io/bengal/))
+- [Parallel page rendering with thread-safe dependency tracking](https://github.com/lbliii/bengal) ([docs](https://lbliii.github.io/bengal/)). Bengal is implemented using a few libraries that show useful patterns for working with the free-threaded interpreter.
+    - [Thread-based ASGI workers with shared immutable config](https://github.com/lbliii/pounce) ([docs](https://lbliii.github.io/pounce/))
+    - [`ContextVar` isolation for per-request state in a web framework](https://github.com/lbliii/chirp) ([docs](https://lbliii.github.io/chirp/))
+    - [AST compilation with copy-on-write filter chains (PEP 703)](https://github.com/lbliii/kida) ([docs](https://lbliii.github.io/kida/))
+    - [Parallel document parsing with an immutable AST](https://github.com/lbliii/patitas) ([docs](https://lbliii.github.io/patitas/))
+    - [Immutable state machines for thread-safe syntax highlighting](https://github.com/lbliii/rosettes) ([docs](https://lbliii.github.io/rosettes/))
+    - [Parallel page rendering with thread-safe dependency tracking](https://github.com/lbliii/bengal) ([docs](https://lbliii.github.io/bengal/))
 
 We'd love to have more examples! See [the contribution guide](../contributing.md)
 if you're interested in adding more use-cases that show off the free-threaded

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -13,6 +13,12 @@ External examples:
 - [Benchmarking a web service on the free-threaded build](https://blog.baro.dev/p/the-future-of-python-web-services-looks-gil-free)
 - [Improved Data Loading on GPUs with Threads](https://developer.nvidia.com/blog/improved-data-loading-with-threads/)
 - [Using `AtomicDict.reduce()` for Multithreaded Aggregation](https://dpdani.github.io/cereggii/examples/AtomicDict/reduce/)
+- [Thread-based ASGI workers with shared immutable config](https://github.com/lbliii/pounce) ([docs](https://lbliii.github.io/pounce/))
+- [`ContextVar` isolation for per-request state in a web framework](https://github.com/lbliii/chirp) ([docs](https://lbliii.github.io/chirp/))
+- [AST compilation with copy-on-write filter chains (PEP 703)](https://github.com/lbliii/kida) ([docs](https://lbliii.github.io/kida/))
+- [Parallel document parsing with an immutable AST](https://github.com/lbliii/patitas) ([docs](https://lbliii.github.io/patitas/))
+- [Immutable state machines for thread-safe syntax highlighting](https://github.com/lbliii/rosettes) ([docs](https://lbliii.github.io/rosettes/))
+- [Parallel page rendering with thread-safe dependency tracking](https://github.com/lbliii/bengal) ([docs](https://lbliii.github.io/bengal/))
 
 We'd love to have more examples! See [the contribution guide](../contributing.md)
 if you're interested in adding more use-cases that show off the free-threaded


### PR DESCRIPTION
Hello! Your contribution guide invites external examples, so I thought I'd share a set of pure-Python libraries I've been building on 3.14t over the past several months.

They're all part of an SSG stack (Bengal) and each one exercises a different free-threading pattern: `ContextVar` request isolation (Chirp), copy-on-write filter chains with a PEP 703 declaration (Kida), thread-based ASGI workers (Pounce), immutable ASTs for parallel parsing (Patitas), and immutable state machines (Rosettes).

Let me know if you'd like a different format or for me to reduce the list to just one. These link to the repos and doc sites -- I don't have dedicated blog posts about them but could look into that if recommended.

Thanks for taking a look.

Links added in PR are below:

- [Thread-based ASGI workers with shared immutable config](https://github.com/lbliii/pounce) ([docs](https://lbliii.github.io/pounce/))
- [`ContextVar` isolation for per-request state in a web framework](https://github.com/lbliii/chirp) ([docs](https://lbliii.github.io/chirp/))
- [AST compilation with copy-on-write filter chains (PEP 703)](https://github.com/lbliii/kida) ([docs](https://lbliii.github.io/kida/))
- [Parallel document parsing with an immutable AST](https://github.com/lbliii/patitas) ([docs](https://lbliii.github.io/patitas/))
- [Immutable state machines for thread-safe syntax highlighting](https://github.com/lbliii/rosettes) ([docs](https://lbliii.github.io/rosettes/))
- [Parallel page rendering with thread-safe dependency tracking](https://github.com/lbliii/bengal) ([docs](https://lbliii.github.io/bengal/))
