### PR TITLE
Update docs meeting page

### DIFF
--- a/docs/docs-meeting.md
+++ b/docs/docs-meeting.md
@@ -1,23 +1,10 @@
-# Monthly Free-threading Documentation Meeting
+## Documentation coordination
 
-We hold a monthly free-threading documentation meeting where contributors and interested
-community members can discuss documentation improvements, share updates, and coordinate
-efforts.
+The free-threading community documentation meeting is current on-hold. For now,
+we are planning to discuss improving CPython documentation for the free-threaded
+build in the regular meeting coordinated by the [CPython Documentation
+Workgroup](https://docs-community.readthedocs.io/workgroup/workgroup_charter.html).
 
-## Meeting Details
-
-**When**: [Second Monday of every month at 4:00 PM UTC (1 hour)](https://calendar.google.com/calendar/u/0?cid=Y19hZTdhMzJiYzQ3OWFiY2JiY2JjNGU5MmI0ZWZhNWQ4MGZjMGVkNTY2N2Y4NjY5YzJkODQ1N2ViMmI4M2ExNGY1QGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20)
-
-**Where**: [Google Meet](https://meet.google.com/dqw-qkeg-jnh)
-
-Everyone is welcome to join! The meeting provides an opportunity to:
-
-- Discuss documentation improvements and additions
-- Share experiences with free-threading adoption
-- Coordinate community efforts
-- Ask questions and get help
-
-## Questions?
-
-If you have any questions about the meeting or would like more information, please reach
-out on the [Free-threaded Python Community Discord](https://discord.gg/rqgHCDqdRr).
+If you are working on documentation for a community project and would like to
+chat or coordinate, please reach out on the out on the [Free-threaded Python
+Community Discord](https://discord.gg/rqgHCDqdRr).


### PR DESCRIPTION
Thanks to @rgommers for pointing this out.

Rather than deleting the page outright, I trimmed it down and added a link to the CPython docs workgroup page.